### PR TITLE
Changed default migrations.run to true

### DIFF
--- a/gate-teamware/Chart.yaml
+++ b/gate-teamware/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gate-teamware/values.yaml
+++ b/gate-teamware/values.yaml
@@ -33,7 +33,7 @@ migrations:
   # false for subsequent ones if there are no DB changes.  We deliberately do not
   # run migrations as part of the regular Django startup as this is dangerous
   # when there may be more than one replica of the backend pod.
-  run: false
+  run: true
   ttl: 300
 
   waitFor:


### PR DESCRIPTION
DB migrations must be run for the initial install in order to get a usable installation, so it makes more sense to run by default with the option to opt out, rather than requiring *all* installs to explicitly opt in.