### PR TITLE
Chart for Teamware 2.1.0

### DIFF
--- a/gate-teamware/Chart.yaml
+++ b/gate-teamware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0"
+appVersion: "2.1.0"
 
 dependencies:
 - name: postgresql

--- a/gate-teamware/README.md
+++ b/gate-teamware/README.md
@@ -145,6 +145,10 @@ and the deployments may need to be manually updated using `kubectl rollout resta
 
 ## Changelog
 
+### Version 2.1.0
+
+Upgraded `appVersion` to [GATE Teamware 2.1.0](https://github.com/GateNLP/gate-teamware/releases/tag/v2.1.0).
+
 ### Version 2.0.0
 
 No breaking changes - this version simply sets the `appVersion` following the release of [GATE Teamware 2.0.0](https://github.com/GateNLP/gate-teamware/releases/tag/v2.0.0).


### PR DESCRIPTION
No change from 2.0.0 apart from the `appVersion`.