### PR TITLE
Upgrade workflow files to latest checkout and changed-files action versions

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -11,14 +11,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Find modified folders
         id: changed-dirs
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v42
         with:
           dir_names: "true"
-          dir_names_exclude_root: "true"
+          dir_names_exclude_current_dir: "true"
           dir_names_max_depth: "1"
 
       - name: Filter for just modified charts
@@ -47,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lockfile exists for ${{ matrix.chart }}
         run: |

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -11,14 +11,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Find modified folders
         id: changed-dirs
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v42
         with:
           dir_names: "true"
-          dir_names_exclude_root: "true"
+          dir_names_exclude_current_dir: "true"
           dir_names_max_depth: "1"
 
       - name: Filter for just modified charts
@@ -48,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Publish chart to GATE repository
         run: |


### PR DESCRIPTION
Currently used versions are node 16 actions, which are deprecated.