### PR TITLE
Don't enforce a version bump for doc-only changes

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -17,11 +17,14 @@ jobs:
 
       - name: Find modified folders
         id: changed-dirs
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v46
         with:
           dir_names: "true"
           dir_names_exclude_current_dir: "true"
           dir_names_max_depth: "1"
+          files_ignore: |
+            **/*.md
+            **/.gitignore
 
       - name: Filter for just modified charts
         id: changed-charts

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -17,11 +17,14 @@ jobs:
 
       - name: Find modified folders
         id: changed-dirs
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v46
         with:
           dir_names: "true"
           dir_names_exclude_current_dir: "true"
           dir_names_max_depth: "1"
+          files_ignore: |
+            **/*.md
+            **/.gitignore
 
       - name: Filter for just modified charts
         id: changed-charts


### PR DESCRIPTION
PRs that _only_ change the chart's README or other `.md` documentation files should not automatically require a version bump and new release of that chart, if there are no changes to the functionality or dependencies.  This will allow us to add notes to a chart's README as it appears on GitHub without forcing the chart to be re-deployed to the GATE repository.